### PR TITLE
added check for null to navbar Avatar in case of photo not found

### DIFF
--- a/client/src/pages/Navbar.js
+++ b/client/src/pages/Navbar.js
@@ -94,7 +94,7 @@ class NavigationBar extends Component {
           <IconButton aria-label="avatar" onClick={this.handleClick}>
             <Avatar
               alt="Remy Sharp"
-              src={profile.photoUrl}
+              src={(profile) ? profile.photoUrl : require("../images/07cc6abd390ab904abbf31db5e6ea20357f8b127.png")}
               className={classes.bigAvatar}
             />
           </IconButton>


### PR DESCRIPTION
There was an issue with adding the Avatar to the page, which also caused an issue with creating a new profile. This request fixes that issue by checking if the profile is found as null within the Avatar, and if so, uses one of the stock photos as a replacement.